### PR TITLE
fix(sort): Quick Sort "Run it" errors

### DIFF
--- a/_sources/sort/quick.rst
+++ b/_sources/sort/quick.rst
@@ -142,12 +142,12 @@ can be invoked recursively on the two halves.
                quick_sort(data, first, pivot);
                quick_sort(data, pivot+1, last);
             }
-
+            return data;
          }
 
          int main() {
            vector<int> data = {54, 26, 93, 17, 77, 31, 44, 55, 20};
-           print(quick_sort(data), 0, data.size()-1);
+           print(quick_sort(data, 0, data.size()-1));
            return 0;
          }
 

--- a/docs/_sources/sort/quick.rst.txt
+++ b/docs/_sources/sort/quick.rst.txt
@@ -142,12 +142,12 @@ can be invoked recursively on the two halves.
                quick_sort(data, first, pivot);
                quick_sort(data, pivot+1, last);
             }
-
+            return data;
          }
 
          int main() {
            vector<int> data = {54, 26, 93, 17, 77, 31, 44, 55, 20};
-           print(quick_sort(data), 0, data.size()-1);
+           print(quick_sort(data, 0, data.size()-1));
            return 0;
          }
 


### PR DESCRIPTION
- Fix missing quick_sort() return statement.
- Fix main quick_sort usage misplaced closing parenthesis.

Side Note:
I also tried rebuilding the project with runescape marklcrns/cisc187-reader@50638b9 using your docker container and latest version of runescape in Debian but your reader seems to be hooked up in a server. "Run It" doesn't seem to work in my github pages:
https://marklcrns.github.io/cisc187-reader/sort/quick.html